### PR TITLE
Support Python 2 and Python 3 with single source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+env:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=pypy
+    - TOXENV=py33
+    - TOXENV=py34
+install:
+    - travis_retry pip install tox==1.6.1
+script:
+    - travis_retry tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py24,py25,py26,py27,jython,pypy
+envlist = py24,py25,py26,py27,py33,py34,jython,pypy
 
 [testenv]
 commands=python unit2.py discover []

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,6 @@
 envlist = py24,py25,py26,py27,py33,py34,jython,pypy
 
 [testenv]
+setenv =
+    PIP_INSECURE=1
 commands=python unit2.py discover []

--- a/unittest2/case.py
+++ b/unittest2/case.py
@@ -941,7 +941,7 @@ class TestCase(unittest.TestCase):
         """Checks whether actual is a superset of expected."""
         missing = []
         mismatched = []
-        for key, value in expected.iteritems():
+        for key, value in expected.items():
             if key not in actual:
                 missing.append(key)
             elif value != actual[key]:

--- a/unittest2/case.py
+++ b/unittest2/case.py
@@ -13,7 +13,7 @@ from unittest2.util import (
     unorderable_list_difference
 )
 
-from unittest2.compatibility import wraps, with_context, catch_warnings
+from unittest2.compatibility import wraps, with_context, catch_warnings, unicode
 
 __unittest = True
 

--- a/unittest2/case.py
+++ b/unittest2/case.py
@@ -116,7 +116,7 @@ class _AssertRaisesBaseContext(object):
                 self.obj_name = str(callable_obj)
         else:
             self.obj_name = None
-        if isinstance(expected_regex, basestring):
+        if hasattr(expected_regex, 'startswith'):
             expected_regex = re.compile(expected_regex)
         self.expected_regex = expected_regex
 
@@ -210,7 +210,7 @@ class _TypeEqualityDict(object):
 
     def __getitem__(self, key):
         value = self._store[key]
-        if isinstance(value, basestring):
+        if hasattr(value, 'startswith'):
             return getattr(self.testcase, value)
         return value
 
@@ -1004,9 +1004,9 @@ class TestCase(unittest.TestCase):
 
     def assertMultiLineEqual(self, first, second, msg=None):
         """Assert that two multi-line strings are equal."""
-        self.assertIsInstance(first, basestring, (
+        self.assertTrue(hasattr(first, 'startswith'), (
                 'First argument is not a string'))
-        self.assertIsInstance(second, basestring, (
+        self.assertTrue(hasattr(second, 'startswith'), (
                 'Second argument is not a string'))
 
         if first != second:
@@ -1117,7 +1117,7 @@ class TestCase(unittest.TestCase):
 
     def assertRegex(self, text, expected_regex, msg=None):
         """Fail the test unless the text matches the regular expression."""
-        if isinstance(expected_regex, basestring):
+        if hasattr(expected_regex, 'startswith'):
             expected_regex = re.compile(expected_regex)
         if not expected_regex.search(text):
             msg = msg or "Regex didn't match"
@@ -1126,7 +1126,7 @@ class TestCase(unittest.TestCase):
 
     def assertNotRegex(self, text, unexpected_regex, msg=None):
         """Fail the test if the text matches the regular expression."""
-        if isinstance(unexpected_regex, basestring):
+        if hasattr(unexpected_regex, 'startswith'):
             unexpected_regex = re.compile(unexpected_regex)
         match = unexpected_regex.search(text)
         if match:

--- a/unittest2/case.py
+++ b/unittest2/case.py
@@ -371,7 +371,8 @@ class TestCase(unittest.TestCase):
             function()
         except KeyboardInterrupt:
             raise
-        except SkipTest, e:
+        except SkipTest:
+            e = sys.exc_info()[1]
             outcome.success = False
             outcome.skipped = str(e)
         except _UnexpectedSuccess:
@@ -560,7 +561,7 @@ class TestCase(unittest.TestCase):
             excName = excClass.__name__
         else:
             excName = str(excClass)
-        raise self.failureException, "%s not raised" % excName
+        raise self.failureException("%s not raised" % excName)
 
     def assertWarns(self, expected_warning, callable_obj=None, *args, **kwargs):
         """Fail unless a warning of class warnClass is triggered
@@ -866,16 +867,20 @@ class TestCase(unittest.TestCase):
         """
         try:
             difference1 = set1.difference(set2)
-        except TypeError, e:
+        except TypeError:
+            e = sys.exc_info()[1]
             self.fail('invalid type when attempting set difference: %s' % e)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.fail('first argument does not support set difference: %s' % e)
 
         try:
             difference2 = set2.difference(set1)
-        except TypeError, e:
+        except TypeError:
+            e = sys.exc_info()[1]
             self.fail('invalid type when attempting set difference: %s' % e)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.fail('second argument does not support set difference: %s' % e)
 
         if not (difference1 or difference2):
@@ -1076,8 +1081,9 @@ class TestCase(unittest.TestCase):
             return _AssertRaisesContext(expected_exception, self, expected_regex)
         try:
             callable_obj(*args, **kwargs)
-        except expected_exception, exc_value:
-            if isinstance(expected_regex, basestring):
+        except expected_exception:
+            exc_value = sys.exc_info()[1]
+            if hasattr(expected_regex, 'startswith'):
                 expected_regex = re.compile(expected_regex)
             if not expected_regex.search(str(exc_value)):
                 raise self.failureException('"%s" does not match "%s"' %
@@ -1087,7 +1093,7 @@ class TestCase(unittest.TestCase):
                 excName = expected_exception.__name__
             else:
                 excName = str(expected_exception)
-            raise self.failureException, "%s not raised" % excName
+            raise self.failureException("%s not raised" % excName)
 
     def assertWarnsRegex(self, expected_warning, expected_regex,
                          callable_obj=None, *args, **kwargs):

--- a/unittest2/case.py
+++ b/unittest2/case.py
@@ -771,7 +771,7 @@ class TestCase(unittest.TestCase):
             elements = (seq_type_name.capitalize(), seq1_repr, seq2_repr)
             differing = '%ss differ: %s != %s\n' % elements
 
-            for i in xrange(min(len1, len2)):
+            for i in range(min(len1, len2)):
                 try:
                     item1 = seq1[i]
                 except (TypeError, IndexError, NotImplementedError):

--- a/unittest2/compatibility.py
+++ b/unittest2/compatibility.py
@@ -12,6 +12,13 @@ except ImportError:
 
 try:
     # Python 2
+    unicode = unicode
+except NameError:
+    # Python 3
+    unicode = str
+
+try:
+    # Python 2
     from StringIO import StringIO
 except ImportError:
     # Python 3

--- a/unittest2/compatibility.py
+++ b/unittest2/compatibility.py
@@ -13,9 +13,13 @@ except ImportError:
 try:
     # Python 2
     unicode = unicode
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
 except NameError:
     # Python 3
     unicode = str
+    def u(s):
+        return s
 
 try:
     # Python 2

--- a/unittest2/compatibility.py
+++ b/unittest2/compatibility.py
@@ -10,6 +10,13 @@ except ImportError:
             return func
         return _wraps
 
+try:
+    # Python 2
+    from StringIO import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
+
 __unittest = True
 
 def _relpath_nt(path, start=os.path.curdir):

--- a/unittest2/loader.py
+++ b/unittest2/loader.py
@@ -18,6 +18,19 @@ except ImportError:
 
 __unittest = True
 
+try:
+    # Python 2
+    cmp = cmp
+except NameError:
+    # Python 3
+    def cmp(a, b):
+        if a < b:
+            return -1
+        elif a > b:
+            return 1
+        else:
+            return 0
+
 
 def _CmpToKey(mycmp):
     'Convert a cmp= function into a key= function'
@@ -68,7 +81,7 @@ class TestLoader(unittest.TestLoader):
     and returning them wrapped in a TestSuite
     """
     testMethodPrefix = 'test'
-    sortTestMethodsUsing = cmp
+    sortTestMethodsUsing = staticmethod(cmp)
     suiteClass = suite.TestSuite
     _top_level_dir = None
 

--- a/unittest2/loader.py
+++ b/unittest2/loader.py
@@ -96,7 +96,8 @@ class TestLoader(unittest.TestLoader):
         if use_load_tests and load_tests is not None:
             try:
                 return load_tests(self, tests, None)
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 return _make_failed_load_tests(module.__name__, e,
                                                self.suiteClass)
         return tests
@@ -302,7 +303,8 @@ class TestLoader(unittest.TestLoader):
                 else:
                     try:
                         yield load_tests(self, tests, pattern)
-                    except Exception, e:
+                    except Exception:
+                        e = sys.exc_info()[1]
                         yield _make_failed_load_tests(package.__name__, e,
                                                       self.suiteClass)
 

--- a/unittest2/loader.py
+++ b/unittest2/loader.py
@@ -157,10 +157,14 @@ class TestLoader(unittest.TestLoader):
         elif (is_unbound_method(obj) and
               isinstance(parent, type) and
               issubclass(parent, case.TestCase)):
-            return self.suiteClass([parent(obj.__name__)])
+            name = obj.__name__
+            inst = parent(name)
+            # static methods follow a different path
+            if not isinstance(getattr(inst, name), types.FunctionType):
+                return self.suiteClass([inst])
         elif isinstance(obj, unittest.TestSuite):
             return obj
-        elif hasattr(obj, '__call__'):
+        if hasattr(obj, '__call__'):
             test = obj()
             if isinstance(test, unittest.TestSuite):
                 return test

--- a/unittest2/loader.py
+++ b/unittest2/loader.py
@@ -176,7 +176,7 @@ class TestLoader(unittest.TestLoader):
                          prefix=self.testMethodPrefix):
             return attrname.startswith(prefix) and \
                 hasattr(getattr(testCaseClass, attrname), '__call__')
-        testFnNames = filter(isTestMethod, dir(testCaseClass))
+        testFnNames = list(filter(isTestMethod, dir(testCaseClass)))
         if self.sortTestMethodsUsing:
             testFnNames.sort(key=_CmpToKey(self.sortTestMethodsUsing))
         return testFnNames

--- a/unittest2/loader.py
+++ b/unittest2/loader.py
@@ -31,6 +31,16 @@ except NameError:
         else:
             return 0
 
+try:
+    # Python 2
+    types.UnboundMethodType
+    def is_unbound_method(f):
+        return isinstance(f, types.UnboundMethodType)
+except AttributeError:
+    # Python3
+    def is_unbound_method(f):
+        return isinstance(f, types.FunctionType)
+
 
 def _CmpToKey(mycmp):
     'Convert a cmp= function into a key= function'
@@ -144,7 +154,7 @@ class TestLoader(unittest.TestLoader):
             return self.loadTestsFromModule(obj)
         elif isinstance(obj, type) and issubclass(obj, unittest.TestCase):
             return self.loadTestsFromTestCase(obj)
-        elif (isinstance(obj, types.UnboundMethodType) and
+        elif (is_unbound_method(obj) and
               isinstance(parent, type) and
               issubclass(parent, case.TestCase)):
             return self.suiteClass([parent(obj.__name__)])

--- a/unittest2/main.py
+++ b/unittest2/main.py
@@ -220,7 +220,7 @@ class TestProgram(object):
             installHandler()
         if self.testRunner is None:
             self.testRunner = runner.TextTestRunner
-        if isinstance(self.testRunner, (type, types.ClassType)):
+        if isinstance(self.testRunner, type):
             try:
                 testRunner = self.testRunner(verbosity=self.verbosity,
                                              failfast=self.failfast,

--- a/unittest2/main.py
+++ b/unittest2/main.py
@@ -99,7 +99,7 @@ class TestProgram(object):
 
     def usageExit(self, msg=None):
         if msg:
-            print msg
+            print(msg)
         usage = {'progName': self.progName, 'catchbreak': '', 'failfast': '',
                  'buffer': ''}
         if self.failfast != False:
@@ -108,7 +108,7 @@ class TestProgram(object):
             usage['catchbreak'] = CATCHBREAK
         if self.buffer != False:
             usage['buffer'] = BUFFEROUTPUT
-        print self.USAGE % usage
+        print(self.USAGE % usage)
         sys.exit(2)
 
     def parseArgs(self, argv):

--- a/unittest2/main.py
+++ b/unittest2/main.py
@@ -76,7 +76,7 @@ class TestProgram(object):
                  argv=None, testRunner=None,
                  testLoader=loader.defaultTestLoader, exit=True,
                  verbosity=1, failfast=None, catchbreak=None, buffer=None):
-        if isinstance(module, basestring):
+        if hasattr(module, 'split'):
             self.module = __import__(module)
             for part in module.split('.')[1:]:
                 self.module = getattr(self.module, part)

--- a/unittest2/main.py
+++ b/unittest2/main.py
@@ -151,7 +151,8 @@ class TestProgram(object):
             else:
                 self.testNames = (self.defaultTest,)
             self.createTests()
-        except getopt.error, msg:
+        except getopt.error:
+            msg = sys.exc_info()[1]
             self.usageExit(msg)
 
     def createTests(self):

--- a/unittest2/result.py
+++ b/unittest2/result.py
@@ -4,10 +4,8 @@ import sys
 import traceback
 import unittest
 
-from StringIO import StringIO
-
 from unittest2 import util
-from unittest2.compatibility import wraps
+from unittest2.compatibility import wraps, StringIO
 
 __unittest = True
 

--- a/unittest2/suite.py
+++ b/unittest2/suite.py
@@ -48,7 +48,7 @@ class BaseTestSuite(unittest.TestSuite):
         self._tests.append(test)
 
     def addTests(self, tests):
-        if isinstance(tests, basestring):
+        if hasattr(tests, 'startswith'):
             raise TypeError("tests must be an iterable of tests, not a string")
         for test in tests:
             self.addTest(test)

--- a/unittest2/suite.py
+++ b/unittest2/suite.py
@@ -137,7 +137,8 @@ class TestSuite(BaseTestSuite):
         if setUpClass is not None:
             try:
                 setUpClass()
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 if isinstance(result, _DebugResult):
                     raise
                 currentClass._classSetupFailed = True
@@ -171,7 +172,8 @@ class TestSuite(BaseTestSuite):
         if setUpModule is not None:
             try:
                 setUpModule()
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 if isinstance(result, _DebugResult):
                     raise
                 result._moduleSetUpFailed = True
@@ -202,7 +204,8 @@ class TestSuite(BaseTestSuite):
         if tearDownModule is not None:
             try:
                 tearDownModule()
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 if isinstance(result, _DebugResult):
                     raise
                 errorName = 'tearDownModule (%s)' % previousModule
@@ -224,7 +227,8 @@ class TestSuite(BaseTestSuite):
         if tearDownClass is not None:
             try:
                 tearDownClass()
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 if isinstance(result, _DebugResult):
                     raise
                 className = util.strclass(previousClass)

--- a/unittest2/test/_test_unittest2_with.py
+++ b/unittest2/test/_test_unittest2_with.py
@@ -42,7 +42,8 @@ class TestWith(unittest2.TestCase):
         self.assertRaises(KeyError, _raise, KeyError("key"))
         try:
             self.assertRaises(KeyError, lambda: None)
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             self.assertIn("KeyError not raised", e.args)
         else:
             self.fail("assertRaises() didn't fail")
@@ -55,7 +56,8 @@ class TestWith(unittest2.TestCase):
         with self.assertRaises(KeyError) as cm:
             try:
                 raise KeyError
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 raise
         self.assertIs(cm.exception, e)
 
@@ -64,7 +66,8 @@ class TestWith(unittest2.TestCase):
         try:
             with self.assertRaises(KeyError):
                 pass
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             self.assertIn("KeyError not raised", e.args)
         else:
             self.fail("assertRaises() didn't fail")

--- a/unittest2/test/_test_unittest2_with.py
+++ b/unittest2/test/_test_unittest2_with.py
@@ -4,6 +4,7 @@ from __future__ import with_statement
 import unittest2
 from unittest2.test.support import OldTestResult
 from unittest2.compatibility import catch_warnings
+from unittest2.compatibility import u
 
 import sys
 import warnings
@@ -85,14 +86,14 @@ class TestWith(unittest2.TestCase):
             one = ''.join(chr(i) for i in range(255))
             # this used to cause a UnicodeDecodeError constructing the failure msg
             with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({'foo': one}, {'foo': u'\uFFFD'})
+                self.assertDictContainsSubset({'foo': one}, {'foo': u('\uFFFD')})
 
     def test_formatMessage_unicode_error(self):
         with catch_warnings(record=True):
             # This causes a UnicodeWarning due to its craziness
             one = ''.join(chr(i) for i in range(255))
             # this used to cause a UnicodeDecodeError constructing msg
-            self._formatMessage(one, u'\uFFFD')
+            self._formatMessage(one, u('\uFFFD'))
 
     def assertOldResultWarning(self, test, failures):
         with self.assertWarns(RuntimeWarning):

--- a/unittest2/test/support.py
+++ b/unittest2/test/support.py
@@ -110,7 +110,8 @@ class HashingMixin(object):
                     self.fail("%r and %r do not hash equal" % (obj_1, obj_2))
             except KeyboardInterrupt:
                 raise
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 self.fail("Problem hashing %r and %r: %s" % (obj_1, obj_2, e))
 
         for obj_1, obj_2 in self.ne_pairs:
@@ -120,6 +121,7 @@ class HashingMixin(object):
                               (obj_1, obj_2))
             except KeyboardInterrupt:
                 raise
-            except Exception, e:
+            except Exception:
+                e = sys.exc_info()[1]
                 self.fail("Problem hashing %s and %s: %s" % (obj_1, obj_2, e))
 

--- a/unittest2/test/test_assertions.py
+++ b/unittest2/test/test_assertions.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 
 import unittest2
 
@@ -64,7 +65,8 @@ class Test_Assertions(unittest2.TestCase):
         self.assertNotRegex('Ala ma kota', r'r+')
         try:
             self.assertNotRegex('Ala ma kota', r'k.t', 'Message')
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             self.assertIn("'kot'", e.args[0])
             self.assertIn('Message', e.args[0])
         else:

--- a/unittest2/test/test_break.py
+++ b/unittest2/test/test_break.py
@@ -3,7 +3,7 @@ import os
 import sys
 import weakref
 
-from cStringIO import StringIO
+from unittest2.compatibility import StringIO
 
 try:
     import signal

--- a/unittest2/test/test_case.py
+++ b/unittest2/test/test_case.py
@@ -767,7 +767,7 @@ test case
             except self.failureException:
                 e = sys.exc_info()[1]
                 # need to remove the first line of the error message
-                error = str(e).encode('utf8').split('\n', 1)[1]
+                error = str(e).split('\n', 1)[1]
 
                 # assertMultiLineEqual is hooked up as the default for
                 # unicode strings - so we can't use it for this check

--- a/unittest2/test/test_case.py
+++ b/unittest2/test/test_case.py
@@ -2,6 +2,7 @@ import difflib
 import pickle
 import pprint
 import re
+import sys
 
 from copy import deepcopy
 
@@ -763,7 +764,8 @@ test case
             try:
                 self.assertMultiLineEqual(type_changer(sample_text),
                                           type_changer(revised_sample_text))
-            except self.failureException, e:
+            except self.failureException:
+                e = sys.exc_info()[1]
                 # need to remove the first line of the error message
                 error = str(e).encode('utf8').split('\n', 1)[1]
 
@@ -783,7 +785,8 @@ test case
         self.maxDiff = len(diff)//2
         try:
             self.assertSequenceEqual(seq1, seq2)
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             msg = e.args[0]
         else:
             self.fail('assertSequenceEqual did not fail.')
@@ -793,7 +796,8 @@ test case
         self.maxDiff = len(diff) * 2
         try:
             self.assertSequenceEqual(seq1, seq2)
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             msg = e.args[0]
         else:
             self.fail('assertSequenceEqual did not fail.')
@@ -803,7 +807,8 @@ test case
         self.maxDiff = None
         try:
             self.assertSequenceEqual(seq1, seq2)
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             msg = e.args[0]
         else:
             self.fail('assertSequenceEqual did not fail.')
@@ -831,7 +836,8 @@ test case
         test._truncateMessage = truncate
         try:
             test.assertDictEqual({}, {1: 0})
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), 'foo')
         else:
             self.fail('assertDictEqual did not fail')
@@ -843,7 +849,8 @@ test case
         test._truncateMessage = truncate
         try:
             test.assertMultiLineEqual('foo', 'bar')
-        except self.failureException, e:
+        except self.failureException:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), 'foo')
         else:
             self.fail('assertMultiLineEqual did not fail')

--- a/unittest2/test/test_case.py
+++ b/unittest2/test/test_case.py
@@ -11,6 +11,7 @@ import unittest2
 from unittest2.test.support import (
     OldTestResult, EqualityMixin, HashingMixin, LoggingResult
 )
+from unittest2.compatibility import u
 
 
 class MyException(Exception):
@@ -694,47 +695,47 @@ class Test_TestCase(unittest2.TestCase, EqualityMixin, HashingMixin):
         self.assertRaises(self.failureException, self.assertLessEqual, 'bug', 'ant')
 
         # Try Unicode
-        self.assertGreater(u'bug', u'ant')
-        self.assertGreaterEqual(u'bug', u'ant')
-        self.assertGreaterEqual(u'ant', u'ant')
-        self.assertLess(u'ant', u'bug')
-        self.assertLessEqual(u'ant', u'bug')
-        self.assertLessEqual(u'ant', u'ant')
-        self.assertRaises(self.failureException, self.assertGreater, u'ant', u'bug')
-        self.assertRaises(self.failureException, self.assertGreater, u'ant', u'ant')
-        self.assertRaises(self.failureException, self.assertGreaterEqual, u'ant',
-                          u'bug')
-        self.assertRaises(self.failureException, self.assertLess, u'bug', u'ant')
-        self.assertRaises(self.failureException, self.assertLess, u'ant', u'ant')
-        self.assertRaises(self.failureException, self.assertLessEqual, u'bug', u'ant')
+        self.assertGreater(u('bug'), u('ant'))
+        self.assertGreaterEqual(u('bug'), u('ant'))
+        self.assertGreaterEqual(u('ant'), u('ant'))
+        self.assertLess(u('ant'), u('bug'))
+        self.assertLessEqual(u('ant'), u('bug'))
+        self.assertLessEqual(u('ant'), u('ant'))
+        self.assertRaises(self.failureException, self.assertGreater, u('ant'), u('bug'))
+        self.assertRaises(self.failureException, self.assertGreater, u('ant'), u('ant'))
+        self.assertRaises(self.failureException, self.assertGreaterEqual, u('ant'),
+                          u('bug'))
+        self.assertRaises(self.failureException, self.assertLess, u('bug'), u('ant'))
+        self.assertRaises(self.failureException, self.assertLess, u('ant'), u('ant'))
+        self.assertRaises(self.failureException, self.assertLessEqual, u('bug'), u('ant'))
 
         # Try Mixed String/Unicode
-        self.assertGreater('bug', u'ant')
-        self.assertGreater(u'bug', 'ant')
-        self.assertGreaterEqual('bug', u'ant')
-        self.assertGreaterEqual(u'bug', 'ant')
-        self.assertGreaterEqual('ant', u'ant')
-        self.assertGreaterEqual(u'ant', 'ant')
-        self.assertLess('ant', u'bug')
-        self.assertLess(u'ant', 'bug')
-        self.assertLessEqual('ant', u'bug')
-        self.assertLessEqual(u'ant', 'bug')
-        self.assertLessEqual('ant', u'ant')
-        self.assertLessEqual(u'ant', 'ant')
-        self.assertRaises(self.failureException, self.assertGreater, 'ant', u'bug')
-        self.assertRaises(self.failureException, self.assertGreater, u'ant', 'bug')
-        self.assertRaises(self.failureException, self.assertGreater, 'ant', u'ant')
-        self.assertRaises(self.failureException, self.assertGreater, u'ant', 'ant')
+        self.assertGreater('bug', u('ant'))
+        self.assertGreater(u('bug'), 'ant')
+        self.assertGreaterEqual('bug', u('ant'))
+        self.assertGreaterEqual(u('bug'), 'ant')
+        self.assertGreaterEqual('ant', u('ant'))
+        self.assertGreaterEqual(u('ant'), 'ant')
+        self.assertLess('ant', u('bug'))
+        self.assertLess(u('ant'), 'bug')
+        self.assertLessEqual('ant', u('bug'))
+        self.assertLessEqual(u('ant'), 'bug')
+        self.assertLessEqual('ant', u('ant'))
+        self.assertLessEqual(u('ant'), 'ant')
+        self.assertRaises(self.failureException, self.assertGreater, 'ant', u('bug'))
+        self.assertRaises(self.failureException, self.assertGreater, u('ant'), 'bug')
+        self.assertRaises(self.failureException, self.assertGreater, 'ant', u('ant'))
+        self.assertRaises(self.failureException, self.assertGreater, u('ant'), 'ant')
         self.assertRaises(self.failureException, self.assertGreaterEqual, 'ant',
-                          u'bug')
-        self.assertRaises(self.failureException, self.assertGreaterEqual, u'ant',
+                          u('bug'))
+        self.assertRaises(self.failureException, self.assertGreaterEqual, u('ant'),
                           'bug')
-        self.assertRaises(self.failureException, self.assertLess, 'bug', u'ant')
-        self.assertRaises(self.failureException, self.assertLess, u'bug', 'ant')
-        self.assertRaises(self.failureException, self.assertLess, 'ant', u'ant')
-        self.assertRaises(self.failureException, self.assertLess, u'ant', 'ant')
-        self.assertRaises(self.failureException, self.assertLessEqual, 'bug', u'ant')
-        self.assertRaises(self.failureException, self.assertLessEqual, u'bug', 'ant')
+        self.assertRaises(self.failureException, self.assertLess, 'bug', u('ant'))
+        self.assertRaises(self.failureException, self.assertLess, u('bug'), 'ant')
+        self.assertRaises(self.failureException, self.assertLess, 'ant', u('ant'))
+        self.assertRaises(self.failureException, self.assertLess, u('ant'), 'ant')
+        self.assertRaises(self.failureException, self.assertLessEqual, 'bug', u('ant'))
+        self.assertRaises(self.failureException, self.assertLessEqual, u('bug'), 'ant')
 
     def testAssertMultiLineEqual(self):
         sample_text = """\
@@ -878,7 +879,7 @@ test case
 
         self.assertRaisesRegex(ExceptionMock, re.compile('expect$'), Stub)
         self.assertRaisesRegex(ExceptionMock, 'expect$', Stub)
-        self.assertRaisesRegex(ExceptionMock, u'expect$', Stub)
+        self.assertRaisesRegex(ExceptionMock, u('expect$'), Stub)
 
     def testAssertNotRaisesRegex(self):
         self.assertRaisesRegex(
@@ -891,7 +892,7 @@ test case
                 lambda: None)
         self.assertRaisesRegex(
                 self.failureException, '^Exception not raised$',
-                self.assertRaisesRegex, Exception, u'x',
+                self.assertRaisesRegex, Exception, u('x'),
                 lambda: None)
 
     def testAssertRaisesRegexMismatch(self):
@@ -906,7 +907,7 @@ test case
         self.assertRaisesRegex(
                 self.failureException,
                 r'"\^Expected\$" does not match "Unexpected"',
-                self.assertRaisesRegex, Exception, u'^Expected$',
+                self.assertRaisesRegex, Exception, u('^Expected$'),
                 Stub)
         self.assertRaisesRegex(
                 self.failureException,

--- a/unittest2/test/test_case.py
+++ b/unittest2/test/test_case.py
@@ -760,7 +760,10 @@ test case
 +     own implementation that does not subclass from TestCase, of course.
 """
         self.maxDiff = None
-        for type_changer in (lambda x: x, lambda x: x.decode('utf8')):
+        type_changers = [lambda x: x]
+        if sys.version_info < (3, ):  # PY3
+            type_changers.append(lambda x: x.decode('utf-8'))
+        for type_changer in type_changers:
             try:
                 self.assertMultiLineEqual(type_changer(sample_text),
                                           type_changer(revised_sample_text))

--- a/unittest2/test/test_case.py
+++ b/unittest2/test/test_case.py
@@ -373,7 +373,7 @@ class Test_TestCase(unittest2.TestCase, EqualityMixin, HashingMixin):
             def runTest(self):
                 pass
 
-        self.assertIsInstance(Foo().id(), basestring)
+        self.assertTrue(hasattr(Foo().id(), 'startswith'))
 
     # "If result is omitted or None, a temporary result object is created
     # and used, but is not made available to the caller. As TestCase owns the

--- a/unittest2/test/test_functiontestcase.py
+++ b/unittest2/test/test_functiontestcase.py
@@ -124,7 +124,7 @@ class Test_FunctionTestCase(unittest2.TestCase):
     def test_id(self):
         test = unittest2.FunctionTestCase(lambda: None)
 
-        self.assertIsInstance(test.id(), basestring)
+        self.assertTrue(hasattr(test.id(), 'startswith'))
 
     # "Returns a one-line description of the test, or None if no description
     # has been provided. The default implementation of this method returns

--- a/unittest2/test/test_loader.py
+++ b/unittest2/test/test_loader.py
@@ -205,7 +205,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromName('')
-        except ValueError, e:
+        except ValueError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "Empty module name")
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise ValueError")
@@ -238,7 +239,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromName('sdasfasfasdf')
-        except ImportError, e:
+        except ImportError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "No module named sdasfasfasdf")
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise ImportError")
@@ -254,7 +256,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromName('unittest2.sdasfasfasdf')
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "'module' object has no attribute 'sdasfasfasdf'")
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise AttributeError")
@@ -271,7 +274,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromName('sdasfasfasdf', unittest2)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "'module' object has no attribute 'sdasfasfasdf'")
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise AttributeError")
@@ -425,7 +429,8 @@ class Test_TestLoader(unittest2.TestCase):
         loader = unittest2.TestLoader()
         try:
             loader.loadTestsFromName('testcase_1.testfoo', m)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "type object 'MyTestCase' has no attribute 'testfoo'")
         else:
             self.fail("Failed to raise AttributeError")
@@ -583,7 +588,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromNames([''])
-        except ValueError, e:
+        except ValueError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "Empty module name")
         else:
             self.fail("TestLoader.loadTestsFromNames failed to raise ValueError")
@@ -618,7 +624,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromNames(['sdasfasfasdf'])
-        except ImportError, e:
+        except ImportError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "No module named sdasfasfasdf")
         else:
             self.fail("TestLoader.loadTestsFromNames failed to raise ImportError")
@@ -634,7 +641,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromNames(['unittest2.sdasfasfasdf', 'unittest2'])
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "'module' object has no attribute 'sdasfasfasdf'")
         else:
             self.fail("TestLoader.loadTestsFromNames failed to raise AttributeError")
@@ -653,7 +661,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromNames(['sdasfasfasdf'], unittest2)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "'module' object has no attribute 'sdasfasfasdf'")
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise AttributeError")
@@ -672,7 +681,8 @@ class Test_TestLoader(unittest2.TestCase):
 
         try:
             loader.loadTestsFromNames(['TestCase', 'sdasfasfasdf'], unittest2)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "'module' object has no attribute 'sdasfasfasdf'")
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise AttributeError")
@@ -821,7 +831,8 @@ class Test_TestLoader(unittest2.TestCase):
         loader = unittest2.TestLoader()
         try:
             loader.loadTestsFromNames(['testcase_1.testfoo'], m)
-        except AttributeError, e:
+        except AttributeError:
+            e = sys.exc_info()[1]
             self.assertEqual(str(e), "type object 'MyTestCase' has no attribute 'testfoo'")
         else:
             self.fail("Failed to raise AttributeError")

--- a/unittest2/test/test_loader.py
+++ b/unittest2/test/test_loader.py
@@ -5,6 +5,13 @@ import unittest2
 from unittest2.loader import cmp
 
 
+def no_module_named_message(module):
+    if sys.version_info < (3, 3):
+        return "No module named %s" % module
+    else:
+        return "No module named '%s'" % module
+
+
 class Test_TestLoader(unittest2.TestCase):
 
     ### Tests for TestLoader.loadTestsFromTestCase
@@ -239,10 +246,11 @@ class Test_TestLoader(unittest2.TestCase):
         loader = unittest2.TestLoader()
 
         try:
-            loader.loadTestsFromName('sdasfasfasdf')
+            module_name = 'sdasfasfasdf'
+            loader.loadTestsFromName(module_name)
         except ImportError:
             e = sys.exc_info()[1]
-            self.assertEqual(str(e), "No module named sdasfasfasdf")
+            self.assertEqual(str(e), no_module_named_message(module_name))
         else:
             self.fail("TestLoader.loadTestsFromName failed to raise ImportError")
 
@@ -624,10 +632,11 @@ class Test_TestLoader(unittest2.TestCase):
         loader = unittest2.TestLoader()
 
         try:
-            loader.loadTestsFromNames(['sdasfasfasdf'])
+            module_name = 'sdasfasfasdf'
+            loader.loadTestsFromNames([module_name])
         except ImportError:
             e = sys.exc_info()[1]
-            self.assertEqual(str(e), "No module named sdasfasfasdf")
+            self.assertEqual(str(e), no_module_named_message(module_name))
         else:
             self.fail("TestLoader.loadTestsFromNames failed to raise ImportError")
 

--- a/unittest2/test/test_loader.py
+++ b/unittest2/test/test_loader.py
@@ -2,6 +2,7 @@ import sys
 import types
 
 import unittest2
+from unittest2.loader import cmp
 
 
 class Test_TestLoader(unittest2.TestCase):

--- a/unittest2/test/test_new_tests.py
+++ b/unittest2/test/test_new_tests.py
@@ -1,9 +1,8 @@
-from cStringIO import StringIO
-
 import unittest
 import unittest2
 
 from unittest2.test.support import resultFactory
+from unittest2.compatibility import StringIO
 
 
 class TestUnittest(unittest2.TestCase):

--- a/unittest2/test/test_program.py
+++ b/unittest2/test/test_program.py
@@ -1,7 +1,6 @@
-from cStringIO import StringIO
-
 import sys
 import unittest2
+from unittest2.compatibility import StringIO
 
 hasInstallHandler = hasattr(unittest2, 'installHandler')
 

--- a/unittest2/test/test_result.py
+++ b/unittest2/test/test_result.py
@@ -1,8 +1,8 @@
 import sys
 import textwrap
-from StringIO import StringIO
 
 import unittest2
+from unittest2.compatibility import StringIO
 
 
 class Test_TestResult(unittest2.TestCase):

--- a/unittest2/test/test_result.py
+++ b/unittest2/test/test_result.py
@@ -342,8 +342,8 @@ class TestOutputBuffering(unittest2.TestCase):
         result._original_stdout = StringIO()
         result._original_stderr = StringIO()
 
-        print 'foo'
-        print >> sys.stderr, 'bar'
+        print('foo')
+        sys.stderr.write('bar\n')
 
         self.assertEqual(out_stream.getvalue(), 'foo\n')
         self.assertEqual(err_stream.getvalue(), 'bar\n')
@@ -381,9 +381,9 @@ class TestOutputBuffering(unittest2.TestCase):
             result._original_stderr = StringIO()
             result._original_stdout = StringIO()
 
-            print >> sys.stdout, 'foo'
+            print('foo')
             if include_error:
-                print >> sys.stderr, 'bar'
+                sys.stderr.write('bar\n')
 
             addFunction = getattr(result, add_attr)
             addFunction(self, (None, None, None))

--- a/unittest2/test/test_runner.py
+++ b/unittest2/test/test_runner.py
@@ -1,7 +1,7 @@
 import pickle
 
-from cStringIO import StringIO
 from unittest2.test.support import LoggingResult, OldTestResult
+from unittest2.compatibility import StringIO
 
 import unittest2
 
@@ -220,7 +220,10 @@ class Test_TextTestRunner(unittest2.TestCase):
     def test_pickle_unpickle(self):
         # Issue #7197: a TextTestRunner should be (un)pickleable. This is
         # required by test_multiprocessing under Windows (in verbose mode).
-        import StringIO
+        try:
+            import StringIO
+        except ImportError:
+            return
         # cStringIO objects are not pickleable, but StringIO objects are.
         stream = StringIO.StringIO("foo")
         runner = unittest2.TextTestRunner(stream)

--- a/unittest2/test/test_setups.py
+++ b/unittest2/test/test_setups.py
@@ -1,9 +1,8 @@
 import sys
 
-from cStringIO import StringIO
-
 import unittest2
 from unittest2.test.support import resultFactory
+from unittest2.compatibility import StringIO
 
 
 class TestSetups(unittest2.TestCase):


### PR DESCRIPTION
Travis CI: [![Build Status](https://travis-ci.org/msabramo/unittest2.svg?branch=py2_and_py3_single_source)](https://travis-ci.org/msabramo/unittest2)
Drone.io: [![Build Status](https://drone.io/bitbucket.org/msabramo/unittest2/status.png)](https://drone.io/bitbucket.org/msabramo/unittest2/latest)

Right now you have to install [`unittest2`](https://pypi.python.org/pypi/unittest2) for Python 2 and [`unittest2py3k`](https://pypi.python.org/pypi/unittest2py3k) for Python 3.

This is a little clunky when using pip requirements files and tox because you have to have two separate requirements files and two separate tox targets. E.g.:

``` ini
# test-requirements-py2.txt
unittest2
mock
lxml
```

``` ini
# test-requirements-py3.txt
unittest2py3k
mock
lxml
```

``` ini
# tox.ini
[testenv]
deps = -r{toxinidir}/test-requirements-py2.txt
commands = python -m discover

[testenv:py33]
deps = -r{toxinidir}/test-requirements-py3.txt

[testenv:py34]
deps = -r{toxinidir}/test-requirements-py3.txt
```

It would be nice if there were one package that supported both.

Google Code issue: https://code.google.com/p/unittest-ext/issues/detail?id=81
Bitbucket (hg) branch: https://bitbucket.org/msabramo/unittest2/branch/py2_and_py3_single_source
GitHub branch: https://github.com/msabramo/unittest2/tree/bm/py2_and_py3_single_source

```
$ /Library/Frameworks/Python.framework/Versions/2.5/bin/tox -e py24,py25
...
[TOX] py24: commands succeeded
[TOX] py25: commands succeeded
[TOX] congratulations :)
```

```
$ /Library/Frameworks/Python.framework/Versions/3.1/bin/pip freeze
argparse==1.2.1
backports.ssl-match-hostname==3.4.0.1
py==1.4.20
tox==1.3
virtualenv==1.6.4
wsgiref==0.1.2

$ /Library/Frameworks/Python.framework/Versions/3.1/bin/tox \
       -e py24,py25,py26,py27,py30,py31,py32,pypy
...
[TOX] py24: commands succeeded
[TOX] py25: commands succeeded
[TOX] py26: commands succeeded
[TOX] py27: commands succeeded
[TOX] py30: commands succeeded
[TOX] py31: commands succeeded
[TOX] py32: commands succeeded
[TOX] pypy: commands succeeded
[TOX] congratulations :)
```

```
$ tox -e py26,py27,py33,py34,pypy
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  congratulations :)
```

Successful Drone.io build: https://drone.io/bitbucket.org/msabramo/unittest2/5

Passing Travis CI build: https://travis-ci.org/msabramo/unittest2/builds/24631644

:smile:

Cc: @voidspace
